### PR TITLE
pin requests version to 2.21 because 2.22 requirs urllib3 v1.25 which…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,5 +43,5 @@
     name:
       - boto3
       - python-gnupg
-      - requests
+      - requests==2.21.0
       - requests-aws4auth


### PR DESCRIPTION
… is not supported by python 2.7 used for cyhy-feeds

Pinning the versions fixed the dmarc.py error when testing in my workspace