### PR TITLE
Cyhy feeds/remove cyhy core dependency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,5 +16,3 @@ galaxy_info:
 dependencies:
   - src: https://github.com/cisagov/ansible-role-pip
     name: pip
-  - src: https://github.com/cisagov/ansible-role-cyhy-core
-    name: cyhy_core

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,5 +1,3 @@
 ---
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
-- src: https://github.com/cisagov/ansible-role-cyhy-core
-  name: cyhy_core

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Download and untar the cyhy-feeds tarball
   unarchive:
-    src: "https://api.github.com/repos/cisagov/cyhy-feeds/tarball/remove_cyhy-core_dependency"
+    src: "https://api.github.com/repos/cisagov/cyhy-feeds/tarball/develop"
     dest: /var/local/cyhy/feeds
     remote_src: yes
     extra_opts:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,3 +45,4 @@
       - python-gnupg
       - requests==2.21.0
       - requests-aws4auth
+      - git+https://github.com/cisagov/mongo-db-from-config

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,4 +45,4 @@
       - python-gnupg
       - requests==2.21.0
       - requests-aws4auth
-      - git+https://github.com/cisagov/mongo-db-from-config
+      - https://github.com/cisagov/mongo-db-from-config/tarball/develop

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Download and untar the cyhy-feeds tarball
   unarchive:
-    src: "https://api.github.com/repos/cisagov/cyhy-feeds/tarball/develop"
+    src: "https://api.github.com/repos/cisagov/cyhy-feeds/tarball/remove_cyhy-core_dependency"
     dest: /var/local/cyhy/feeds
     remote_src: yes
     extra_opts:


### PR DESCRIPTION
This change is to support the new requirement for mongo-db-from-config needed by https://github.com/cisagov/cyhy-feeds/pull/26 to address https://github.com/cisagov/cyhy-feeds/issues/17