### PR TITLE
Update supported platforms

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,28 +15,20 @@ galaxy_info:
   min_ansible_version: 2.10
   namespace: cisagov
   platforms:
-    # - name: Amazon
-    #   versions:
-    #     - 2
+    # cyhy-feeds is still Python 2, and with distributions ending
+    # support for Python 2 we can only support a limited number of
+    # platforms.
     - name: Debian
       versions:
         - stretch
-    #     - buster
-    #     - bullseye
-    #     # Kali linux isn't an option here, but it is based on
-    #     # Debian Testing:
-    #     # https://www.kali.org/docs/policy/kali-linux-relationship-with-debian
-    #     - bookworm
-    # - name: Fedora
-    #   versions:
-    #     - 34
-    #     - 35
-    # - name: Ubuntu
-    #   versions:
-    #     - bionic
-    #     - focal
+        - buster
+    - name: Ubuntu
+      versions:
+        - bionic
   role_name: cyhy_feeds
 
 dependencies:
   - name: pip
     src: https://github.com/cisagov/ansible-role-pip
+    vars:
+      install_pip2: true

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -16,13 +16,16 @@ lint: |
   ansible-lint
   flake8
 platforms:
+  # cyhy-feeds is still Python 2, and with distributions ending
+  # support for Python 2 we can only support a limited number of
+  # platforms.
   # - name: amazonlinux2
   #   image: amazonlinux:2
   - name: debian9
     image: debian:stretch-slim
     dockerfile: Dockerfile_debian_9.j2
-  # - name: debian10
-  #   image: debian:buster-slim
+  - name: debian10
+    image: debian:buster-slim
   # - name: debian11
   #   image: debian:bullseye-slim
   # - name: debian12
@@ -33,8 +36,8 @@ platforms:
   #   image: fedora:34
   # - name: fedora35
   #   image: fedora:35
-  # - name: ubuntu18
-  #   image: ubuntu:bionic
+  - name: ubuntu18
+    image: ubuntu:bionic
   # - name: ubuntu20
   #   image: ubuntu:focal
 provisioner:

--- a/molecule/default/python.yml
+++ b/molecule/default/python.yml
@@ -1,9 +1,12 @@
 ---
 - hosts: all
-  name: Install pip3/python3 and remove pip2/python2
+  name: Install pip3/python3 and pip2/python2
   become: yes
   become_method: sudo
   roles:
-    - pip
-    - python
-    - remove_python2
+    - role: pip
+      vars:
+        install_pip2: true
+    - role: python
+      vars:
+        install_python2: true

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,9 +1,7 @@
 ---
 - name: pip
   src: https://github.com/cisagov/ansible-role-pip
-  version: improvement/control-installation-of-pip2-via-role-var
 - name: python
   src: https://github.com/cisagov/ansible-role-python
-  version: improvement/control-installation-of-python2-via-role-var
 - name: upgrade
   src: https://github.com/cisagov/ansible-role-upgrade

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,9 +1,9 @@
 ---
-- src: https://github.com/cisagov/ansible-role-pip
-  name: pip
-- src: https://github.com/cisagov/ansible-role-python
-  name: python
-- src: https://github.com/cisagov/ansible-role-remove-python2
-  name: remove_python2
-- src: https://github.com/cisagov/ansible-role-upgrade
-  name: upgrade
+- name: pip
+  src: https://github.com/cisagov/ansible-role-pip
+  version: improvement/control-installation-of-pip2-via-role-var
+- name: python
+  src: https://github.com/cisagov/ansible-role-python
+  version: improvement/control-installation-of-python2-via-role-var
+- name: upgrade
+  src: https://github.com/cisagov/ansible-role-upgrade

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -18,9 +18,7 @@ def test_packages(host, pkg):
     assert host.package(pkg).is_installed
 
 
-@pytest.mark.parametrize(
-    "pkg", ["boto3", "python-gnupg", "requests", "requests-aws4auth"]
-)
+@pytest.mark.parametrize("pkg", ["cyhy-feeds", "mongo-db-from-config"])
 def test_pip_packages(host, pkg):
     """Test that the pip packages were installed."""
     assert pkg in host.pip.get_packages(pip_path="/usr/bin/pip2")

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -23,7 +23,7 @@ def test_packages(host, pkg):
 )
 def test_pip_packages(host, pkg):
     """Test that the pip packages were installed."""
-    assert pkg in host.pip.get_packages()
+    assert pkg in host.pip.get_packages(pip_path="/usr/bin/pip2")
 
 
 @pytest.mark.parametrize(

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,9 +45,11 @@
 # for the cyhy-feeds project.
 - name: Install pip dependency mongo-db-from-config through url
   ansible.builtin.pip:
+    executable: /usr/bin/pip2
     name: https://github.com/cisagov/mongo-db-from-config/tarball/develop
 
 - name: Install other pip dependencies through requirements.txt
   ansible.builtin.pip:
     chdir: /var/local/cyhy/feeds
+    executable: /usr/bin/pip2
     requirements: requirements.txt

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,9 @@
 - name: Install pip dependency mongo-db-from-config through url
   ansible.builtin.pip:
     executable: /usr/bin/pip2
-    name: https://github.com/cisagov/mongo-db-from-config/tarball/develop
+    # This is the last commit before the cisagov/mongo-db-from-config project
+    # became Python 3 only
+    name: https://github.com/cisagov/mongo-db-from-config/tarball/021bb2ceae01b918f863592269899185f17ac2f4
 
 - name: Install other pip dependencies through requirements.txt
   ansible.builtin.pip:


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the platforms supported by this Ansible role in addition to ensuring that the [cyhy-feeds](https://github.com/cisagov/cyhy-feeds) package is installed with `pip2`.

## ⚠ Note ##

This pull request is reliant on the merge of the following PRs:

- cisagov/ansible-role-cyhy-feeds#8
- cisagov/ansible-role-pip#50
- cisagov/ansible-role-python#46

## 💭 Motivation and context ##

We are in the process of updating the instances in [cisagov/cyhy_amis](https://github.com/cisagov/cyhy_amis) to use Debian Buster for instances running Python 2 code. With the above mentioned PRs for Python/pip installation we can expand the supported platforms.

## 🧪 Testing ##

Automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert dependencies to default branches.