### PR TITLE
Install `cisagov/cyhy-feeds` as a Python 3 package

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,10 +20,26 @@ galaxy_info:
   min_ansible_version: "2.10"
   namespace: cisagov
   platforms:
+    # Amazon Linux 2023 has a gnupg2-minimal package installed by default which
+    # creates a conflict when trying to install the full package.
+    # - name: Amazon Linux 2023
+    #   versions:
+    #     - any
     - name: Debian
       versions:
         - buster
+        - bullseye
+        - bookworm
+    - name: Fedora
+      versions:
+        - "36"
+        - "37"
+    - name: Kali
+      versions:
+        - "2023"
     - name: Ubuntu
       versions:
         - bionic
+        - focal
+        - jammy
   role_name: cyhy_feeds

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,12 +2,8 @@
 dependencies:
   - name: pip
     src: https://github.com/cisagov/ansible-role-pip
-    vars:
-      install_pip2: true
   - name: python
     src: https://github.com/cisagov/ansible-role-python
-    vars:
-      install_python2: true
 galaxy_info:
   author: Shane Frasier
   company: CISA Cyber Assessments
@@ -24,9 +20,6 @@ galaxy_info:
   min_ansible_version: "2.10"
   namespace: cisagov
   platforms:
-    # cyhy-feeds is still Python 2, and with distributions ending
-    # support for Python 2 we can only support a limited number of
-    # platforms.
     - name: Debian
       versions:
         - buster

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -16,9 +16,6 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  # cyhy-feeds is still Python 2, and with distributions ending
-  # support for Python 2 we can only support a limited number of
-  # platforms.
   # - image: amazonlinux:2023
   #   name: amazonlinux2023
   #   platform: amd64

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -16,36 +16,38 @@ lint: |
   ansible-lint
   flake8
 platforms:
+  # Amazon Linux 2023 has a gnupg2-minimal package installed by default which
+  # creates a conflict when trying to install the full package.
   # - image: amazonlinux:2023
   #   name: amazonlinux2023
   #   platform: amd64
   - image: debian:buster-slim
     name: debian10
     platform: amd64
-  # - image: debian:bullseye-slim
-  #   name: debian11
-  #   platform: amd64
-  # - image: debian:bookworm-slim
-  #   name: debian12
-  #   platform: amd64
-  # - image: kalilinux/kali-rolling
-  #   name: kali
-  #   platform: amd64
-  # - image: fedora:36
-  #   name: fedora36
-  #   platform: amd64
-  # - image: fedora:37
-  #   name: fedora37
-  #   platform: amd64
+  - image: debian:bullseye-slim
+    name: debian11
+    platform: amd64
+  - image: debian:bookworm-slim
+    name: debian12
+    platform: amd64
+  - image: kalilinux/kali-rolling
+    name: kali
+    platform: amd64
+  - image: fedora:36
+    name: fedora36
+    platform: amd64
+  - image: fedora:37
+    name: fedora37
+    platform: amd64
   - image: ubuntu:bionic
     name: ubuntu18
     platform: amd64
-  # - image: ubuntu:focal
-  #   name: ubuntu20
-  #   platform: amd64
-  # - image: ubuntu:jammy
-  #   name: ubuntu22
-  #   platform: amd64
+  - image: ubuntu:focal
+    name: ubuntu20
+    platform: amd64
+  - image: ubuntu:jammy
+    name: ubuntu22
+    platform: amd64
 scenario:
   name: default
 verifier:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -18,10 +18,13 @@ def test_packages(host, pkg):
     assert host.package(pkg).is_installed
 
 
+# We only have an explicit check for the mongo-db-from-config package because
+# it is installed explicitly for Ubuntu Bionic. If support for Ubuntu Bionic is
+# dropped then we can also drop that package from this list.
 @pytest.mark.parametrize("pkg", ["cyhy-feeds", "mongo-db-from-config"])
 def test_pip_packages(host, pkg):
     """Test that the pip packages were installed."""
-    assert pkg in host.pip.get_packages(pip_path="/usr/bin/pip2")
+    assert pkg in host.pip.get_packages(pip_path="pip3")
 
 
 @pytest.mark.parametrize(

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,4 +55,10 @@
   ansible.builtin.pip:
     chdir: /var/local/cyhy/feeds
     executable: pip3
+    # The extra argument is necessary on Debian 12, which correctly
+    # recognizes that the local Python is externally managed
+    # (i.e. managed via the system package manager and not by pip).
+    # The extra argument is understood by pip on Debian 12 and Kali
+    # systems, but not others.
+    extra_args: "{{ (ansible_distribution == 'Kali' or (ansible_distribution == 'Debian' and ansible_distribution_release == 'bookworm')) | ternary('--break-system-packages', omit) }}"
     requirements: requirements.txt

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,18 +40,19 @@
       - gnupg2
       - unzip
 
-# This is necessary because the version of pip being used does not support
-# PEP 508 style url version pinning which is what is being used in setup.py
-# for the cyhy-feeds project.
+# This is necessary because the version of pip3 available on Ubuntu Bionic does
+# not support PEP 508 style url version pinning which is what is being used in
+# setup.py for the cyhy-feeds project.
 - name: Install pip dependency mongo-db-from-config through url
   ansible.builtin.pip:
-    executable: /usr/bin/pip2
-    # This is the last commit before the cisagov/mongo-db-from-config project
-    # became Python 3 only
-    name: https://github.com/cisagov/mongo-db-from-config/tarball/021bb2ceae01b918f863592269899185f17ac2f4
+    executable: pip3
+    name: https://github.com/cisagov/mongo-db-from-config/tarball/develop
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_release == "bionic"
 
 - name: Install other pip dependencies through requirements.txt
   ansible.builtin.pip:
     chdir: /var/local/cyhy/feeds
-    executable: /usr/bin/pip2
+    executable: pip3
     requirements: requirements.txt


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the installation process to install [cisagov/cyhy-feeds](https://github.com/cisagov/cyhy-feeds) as a Python 3 package. As part of that process the platforms supported by this role were updated.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

With the merge of https://github.com/cisagov/cyhy-feeds/pull/43 the package installation process needed to be updated. Since we no longer require Python 2 it also expands the platforms we are able to support.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I used this in my development [CyHy](https://github.com/cisagov/cyhy_amis) environment and confirmed deployment and functionality.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
